### PR TITLE
Set Rails to 3.2.12 in Gemfile to match the version installed at beginni...

### DIFF
--- a/guides/1_ruby_on_rails_blog_step_by_step.md
+++ b/guides/1_ruby_on_rails_blog_step_by_step.md
@@ -308,7 +308,7 @@ Up until this point we've been using SQLite as our database, but unfortunately H
 <code lang="ruby">
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.13'
+gem 'rails', '3.2.12'
 
 group :development, :test do
   gem 'sqlite3'


### PR DESCRIPTION
The packqge given to alumni contains a 3.2.12 version of Rails.
This commit set a Gemfile example to match the version, preventing a second download of rails.
