### PR TITLE
runs db:migrate detached from Heroku

### DIFF
--- a/guides/1_ruby_on_rails_blog_step_by_step.md
+++ b/guides/1_ruby_on_rails_blog_step_by_step.md
@@ -352,9 +352,10 @@ Now we push our application to Heroku:
 
 Finally we setup our database:
 
-`heroku run rake db:setup`
+`heroku run:detached rake db:setup`
 
-This setup should only need to take place the first time you deploy to heroku. Afterwards you may need to run `db:migrate` instead.
+This setup should only need to take place the first time you deploy to heroku. Afterwards you may need to run `db:migrate` instead.  
+The `detached` option runs the command in the background. It is there only to ensure the process will go through, even on faulty Internet connection. You can use `heroku logs` to view the output of the command.
 
 Finally you should be able to browse to the URL that Heroku has given you and check to see that your blog has been deployed properly!
 


### PR DESCRIPTION
Running Heroku detached prevents the (sometime bad) internet connnection or proxy setting from failing the db:migrate.
A small note tries to explain it in the guide, too.
