### PR TITLE
Fix typo, and make more readable

### DIFF
--- a/source/guides/installfest/getting_started.md
+++ b/source/guides/installfest/getting_started.md
@@ -118,7 +118,7 @@ We'll also want to make our blog listing prettier too, we'll use a Rails partial
  <%= simple_format @post.body %>
 ```
 
-Out of `app/views/posts/show.html.erb` and put it in our `_post.html.erb` file. After that, change all the `@post` to be `post` instead. This means your `_post.html.erb` file will be:
+Out of `app/views/posts/show.html.erb` and put it in our `_post.html.erb` file. After that, change all three mentions of `@post` to be `post` instead. This means your `_post.html.erb` file will be:
 
 ```erb
  <h2><%= link_to_unless_current post.title, post %></h2>

--- a/source/guides/installfest4/getting_started.md
+++ b/source/guides/installfest4/getting_started.md
@@ -116,7 +116,7 @@ We'll also want to make our blog listing prettier too, we'll use a Rails partial
  <%= simple_format @post.body %>
 ```
 
-Out of `app/views/posts/show.html.erb` and put it in our `_post.html.erb` file. After that, change all the `@post` to be `post` instead. This means your `_post.html.erb` file will be:
+Out of `app/views/posts/show.html.erb` and put it in our `_post.html.erb` file. After that, change all three mentions of `@post` to be `post` instead. This means your `_post.html.erb` file will be:
 
 ```erb
  <h2><%= link_to_unless_current post.title, post %></h2>
@@ -263,7 +263,7 @@ class CommentsController < ApplicationController
 end
 ```
 
-The big difference here from the Rails 3 guide is that we use a method called `comment_params` to only choose the parameters from the form that we wan't to save to the model. You can read more about
+The big difference here from the Rails 3 guide is that we use a method called `comment_params` to only choose the parameters from the form that we want to save to the model. You can read more about
 this at: https://github.com/rails/strong_parameters
 
 #### Putting comments into your HTML view


### PR DESCRIPTION
Fix a typo with "wan't", and also make an instruction on replacing an instance variable with a method call more readable.
