### PR TITLE
Fix Rails version in Gemfile snippets

### DIFF
--- a/source/guides/installfest/finishing_a_basic_blog.md
+++ b/source/guides/installfest/finishing_a_basic_blog.md
@@ -228,7 +228,7 @@ We'll be installing Foundation using the zurb-foundation gem by adding it to our
 ```ruby
 source 'https://rubygems.org'
 
-gem 'rails', '~> 3.2.12'
+gem 'rails', '3.2.13'
 
  # For gems only used in development
 group :development, :test do

--- a/source/guides/installfest/getting_started.md
+++ b/source/guides/installfest/getting_started.md
@@ -315,7 +315,7 @@ Up until this point we've been using SQLite as our database, but unfortunately H
 ```ruby
 source 'https://rubygems.org'
 
-gem 'rails', '3.2.12'
+gem 'rails', '3.2.13'
 
 group :development, :test do
   gem 'sqlite3'


### PR DESCRIPTION
Fixed the Rails version used in Gemfile snippets to match the Rails version used in the ‘Getting started on Mavericks’ guide. Also removed the ‘~>’ in the second Gemfile snippet to reduce changes to the learner's Gemfile.
