### PR TITLE
Removed attr_accessible lines

### DIFF
--- a/source/guides/installfest4/testing_the_blog.md
+++ b/source/guides/installfest4/testing_the_blog.md
@@ -105,8 +105,7 @@ Since we're writing a fully functional spec for code that is already written, we
 
 ```ruby
 class Post < ActiveRecord::Base
-  attr_accessible :body, :title
-
+  
   has_many :comments
 
   # validates_presence_of :body, :title


### PR DESCRIPTION
In Rails 4.0, attr_accessible lines is not longer required as it's been deprecated.

Removing that line will let the rspec unit test passed or failed.
