### PR TITLE
Add a general getting started guide.

### DIFF
--- a/source/guides/getting_started.md
+++ b/source/guides/getting_started.md
@@ -1,0 +1,25 @@
+---
+github_url: https://github.com/reinteractive-open/installfest_guides/tree/master/source/guides/getting_started.md
+---
+
+# Getting Started
+## Preparation
+
+#### Prerequisites
+
+1. A working version of Rails which you can install using [Rails Installer](http://railsinstaller.org/) for Windows or Mac. Note: For Mac Mavericks users, please use [this alternative guide on getting started](/guides/installfest41/rails_on_mavericks).
+2. Sublime Text 2. If you prefer another text editor like vim, emacs or TextMate that's fine too but these instructions will specifically mention Sublime.
+
+#### Next steps
+
+Once you've successfully installed Rails (either using the [Rails Installer](http://railsinstaller.org/), by yourself or using the [OSX Mavericks guide](/guides/installfest/rails_on_mavericks)) you're ready to start, but first we need to determine which version of Rails you're using. Open a command prompt and type:
+
+```
+rails -v
+```
+
+Depending on which version of Rails you've installed you should continue using the the correct guide:
+
+* **For Rails version 3.2 continue on our [version 3.2 guide](/guides/installfest/getting_started)**
+* **For Rails version 4.0 continue on our [version 4.0 guide](/guides/installfest40/getting_started)**
+* **For Rails version 4.1 continue on our [version 4.1 guide](/guides/installfest41/getting_started)**

--- a/source/guides/installfest40/getting_started.md
+++ b/source/guides/installfest40/getting_started.md
@@ -7,7 +7,7 @@ github_url: https://github.com/reinteractive-open/installfest_guides/tree/master
 
 #### Prerequisites
 
-1. A working version of Rails 4.0. To determine if you've got a working version of Rails 4.0, type `rails -v` into your command prompt, or as a mentor.
+1. A working version of Rails 4.0. To determine if you've got a working version of Rails 4.0, type `rails -v` into your command prompt.
 2. Sublime Text 2. If you prefer another text editor like vim, emacs or TextMate that's fine too but these instructions will specifically mention Sublime.
 
 #### Next steps

--- a/source/guides/installfest41/getting_started.md
+++ b/source/guides/installfest41/getting_started.md
@@ -7,7 +7,7 @@ github_url: https://github.com/reinteractive-open/installfest_guides/tree/master
 
 #### Prerequisites
 
-1. A working version of Rails 4.1. To determine if you've got a working version of Rails 4.1, type `rails -v` into your command prompt, or as a mentor.
+1. A working version of Rails 4.1. To determine if you've got a working version of Rails 4.1, type `rails -v` into your command prompt.
 2. Sublime Text 2. If you prefer another text editor like vim, emacs or TextMate that's fine too but these instructions will specifically mention Sublime.
 
 #### Next steps

--- a/source/index.html.erb
+++ b/source/index.html.erb
@@ -1,6 +1,6 @@
 <div id="subheading">
   <h2><strong>Free</strong> help to get started developing</br><strong>Ruby on Rails</strong> applications.</h2>
-  <%= link_to 'Start Tutorial', '/guides/installfest/getting_started', :class => 'button' %>
+  <%= link_to 'Start Tutorial', '/guides/getting_started', :class => 'button' %>
   <!-- <h3> -->
   <!-- or -->
   <!-- </h3> -->


### PR DESCRIPTION
The general getting started guide provides a single entry-point
into the installfest guides and properly pushes people into the
correct guide version for their Rails installation.

Updates the front-page link to head to the general getting started
guide instead of the Rails 3.2 guide.
