### PR TITLE
add hyperlink for Ubuntu GNU/Linux from gorails.com at Prerequisites

### DIFF
--- a/source/guides/getting_started.md
+++ b/source/guides/getting_started.md
@@ -3,7 +3,7 @@
 
 #### Prerequisites
 
-1. A working version of Rails which you can install using [Rails Installer](http://railsinstaller.org/) for Windows or Mac. Note: For Mac Mavericks users, please use [this alternative guide on getting started](/guides/installfest41/rails_on_mavericks).
+1. A working version of Rails which you can install using [Rails Installer](http://railsinstaller.org/) for Windows or Mac. Note: For Mac Mavericks users, please use [this alternative guide on getting started](/guides/installfest41/rails_on_mavericks). For Ubuntu GNU/Linux users, you may refer to [gorails guide](https://gorails.com/setup/ubuntu/15.04).
 2. Sublime Text 2. If you prefer another text editor like vim, emacs or TextMate that's fine too but these instructions will specifically mention Sublime.
 
 #### Next steps


### PR DESCRIPTION
Add hyperlink for Ubuntu users on how to setup/install ruby/rails. Just in case someone at installfest is using Ubuntu. 