### PR TITLE
Make earlier guides less visible

### DIFF
--- a/source/guides/getting_started.md
+++ b/source/guides/getting_started.md
@@ -14,8 +14,12 @@ Once you've successfully installed Rails (either using the [Rails Installer](htt
 rails -v
 ```
 
-Depending on which version of Rails you've installed you should continue using the the correct guide:
+Ideally, this should be Rails 4.2.
 
-* **For Rails version 3.2 continue on our [version 3.2 guide](/guides/installfest/getting_started)**
-* **For Rails version 4.0 continue on our [version 4.0 guide](/guides/installfest40/getting_started)**
+* **For Rails version 4.2 use our [version 4.2 guide](/guides/installfest42/getting_started)**
+
+However, if you have an earlier version of Rails you can find the correct guide here:
+
 * **For Rails version 4.1 continue on our [version 4.1 guide](/guides/installfest41/getting_started)**
+* **For Rails version 4.0 continue on our [version 4.0 guide](/guides/installfest40/getting_started)**
+* **For Rails version 3.2 continue on our [version 3.2 guide](/guides/installfest/getting_started)**

--- a/source/layouts/guides.erb
+++ b/source/layouts/guides.erb
@@ -19,7 +19,7 @@
       <aside>
         <h3>Guides</h3>
         <h4>Installfest Rails 4.2</h4>
-        <p>This guide is currently based on Rails 4.2</p>
+        <p>This guide is based on Rails 4.2</p>
         <ul>
           <li><%= link_to 'Getting Started',          '/guides/installfest42/getting_started' %></li>
           <li><%= link_to 'Finishing a Basic Blog',   '/guides/installfest42/finishing_a_basic_blog' %></li>
@@ -27,41 +27,6 @@
           <li><%= link_to 'Admin and Markdown',       '/guides/installfest42/admin_and_markdown' %></li>
           <li><%= link_to 'Understanding Migrations', '/guides/installfest42/understanding_migrations' %></li>
           <li><%= link_to 'Assets and Errors',        '/guides/installfest42/assets_and_errors' %></li></br>
-        </ul>
-
-        <h4>Previous Versions</h4>
-
-        <h4>Installfest Rails 4.1</h4>
-        <p>This is the guide for Rails 4.1</p>
-        <ul>
-          <li><%= link_to 'Getting Started',          '/guides/installfest41/getting_started' %></li>
-          <li><%= link_to 'Finishing a Basic Blog',   '/guides/installfest41/finishing_a_basic_blog' %></li>
-          <li><%= link_to 'Testing the Blog',         '/guides/installfest41/testing_the_blog' %></li>
-          <li><%= link_to 'Admin and Markdown',       '/guides/installfest41/admin_and_markdown' %></li>
-          <li><%= link_to 'Understanding Migrations', '/guides/installfest41/understanding_migrations' %></li>
-          <li><%= link_to 'Assets and Errors',        '/guides/installfest41/assets_and_errors' %></li></br>
-        </ul>
-
-        <h4>Installfest Rails 4.0</h4>
-        <p>This is the guide for Rails 4.0 </p>
-        <ul>
-          <li><%= link_to 'Getting Started',          '/guides/installfest40/getting_started' %></li>
-          <li><%= link_to 'Finishing a Basic Blog',   '/guides/installfest40/finishing_a_basic_blog' %></li>
-          <li><%= link_to 'Testing the Blog',         '/guides/installfest40/testing_the_blog' %></li>
-          <li><%= link_to 'Admin and Markdown',       '/guides/installfest40/admin_and_markdown' %></li>
-          <li><%= link_to 'Understanding Migrations', '/guides/installfest40/understanding_migrations' %></li>
-          <li><%= link_to 'Assets and Errors',        '/guides/installfest40/assets_and_errors' %></li></br>
-        </ul>
-
-        <h4>Installfest Rails 3.2</h4>
-        <p>This is the guide for Rails 3.2</p>
-        <ul>
-          <li><%= link_to 'Getting Started',          '/guides/installfest/getting_started' %></li>
-          <li><%= link_to 'Finishing a Basic Blog',   '/guides/installfest/finishing_a_basic_blog' %></li>
-          <li><%= link_to 'Testing the Blog',         '/guides/installfest/testing_the_blog' %></li>
-          <li><%= link_to 'Admin and Markdown',       '/guides/installfest/admin_and_markdown' %></li>
-          <li><%= link_to 'Understanding Migrations', '/guides/installfest/understanding_migrations' %></li>
-          <li><%= link_to 'Assets and Errors',        '/guides/installfest/assets_and_errors' %></li></br>
         </ul>
 
         <h3>Further Help</h3>


### PR DESCRIPTION
Participants have been using the Rails 3.2 guide as it was the first one in the list.