### PR TITLE
Remove Gem rails_12factor

### DIFF
--- a/source/guides/installfest/getting_started.md
+++ b/source/guides/installfest/getting_started.md
@@ -468,8 +468,6 @@ group :development do
   gem 'spring-watcher-listen', '~> 2.0.0'
 end
 
-gem 'rails_12factor', group: :production
-
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 ```


### PR DESCRIPTION
As of Rails 5, the rails_12factor gem is no longer necessary - see "Rails 5 and Beyond" at the bottom of this page: https://github.com/heroku/rails_12factor