### PR TITLE
Update rails_on_mac.md

### DIFF
--- a/source/guides/installfest/rails_on_mac.md
+++ b/source/guides/installfest/rails_on_mac.md
@@ -1,11 +1,11 @@
-# Getting started on OS X
+# Getting started on macOS
 
-These instructions are for OS X versions 10.9 and above. If you are running an older version of OS X, please see your event host. We will have USB drives with the files you need to install Rails.
+These instructions are for macOS Sierra 10.12.1 and above. If you are running an older version of OS X, please see your event host. We will have USB drives with the files you need to install Rails.
 
 Here is the basic outline of what we will do:
 
-1. Install a text editor (Sublime)
-2. Setup a compiler
+1. Install a text editor of your choice (for ex. Sublime Text 2)
+2. Setup a [gcc/LLVM compiler](https://developer.apple.com/library/content/documentation/CompilerTools/Conceptual/LLVMCompilerOverview/index.html)
 3. Install [homebrew](http://brew.sh)
 4. Use homebrew to install [ruby-install](https://github.com/postmodern/ruby-install) and [chruby](https://github.com/postmodern/chruby)
 5. Use ruby-install to install a new version of the Ruby programming language
@@ -13,17 +13,20 @@ Here is the basic outline of what we will do:
 
 ## Install a Text Editor
 
-Go to [the Sublime website](https://www.sublimetext.com/2) and click on the link for OS X.<br />
-It will download a disk image for Sublime 2 to your downloads folder.<br />
+Go to [the Sublime website](https://www.sublimetext.com/2) and click on the link for OS X.
+It will download a disk image for Sublime 2 to your downloads folder.
 Locate the file and click on it to install. Follow the instructions.
 
-## Setting up a compiler
+## Setting up a gcc/LLVM compiler
+ 
+With the installation of Xcode 8.1 you get the Command-Line tools installed by default. You can ensure it by running `gcc` in terminal. If it gives you this error: `clang: error: no input files`, then you already have the Command Line Tools installed. You can also check it in the Xcode GUI: Xcode->Preferences->Locations->Command Line Tools. If Command-Line Tools are installed you can move to the next section - [installing homebrew]().
 
-1. Open the Terminal application. You can do this by pressing Command+Space (to open Spotlight) then typing "terminal" in
-in the search window which appears.
-2. In the Terminal type: `xcode-select --install` or alternatively `gcc` and press enter. A popup will appear which will install the command-line compilation tools.
+But in case Command Line tools were not installed for some reason proceed with following steps:
+
+1. Open the [Terminal application](https://en.wikipedia.org/wiki/Terminal_(macOS)) (<kbd>⌘</kbd> + <kbd>Space</kbd> (to open [Spotlight](https://support.apple.com/en-au/HT204014)) then type "terminal" in the search bar and press <kbd>Return</kbd>).
+2. In the Terminal type: `xcode-select --install` or alternatively `gcc` and press enter. A popup will appear which will install the command-line compilation tools. You may be required to enter your profile password.
 3. You may receive a warning like: "_You have not agreed to the Xcode license agreements, please run 'xcodebuild -license'_". If so, simply run: `sudo xcodebuild -license` and enter your account password then follow the steps.
-4. Once that has finished try typing `gcc -v` into your terminal window. You should see a message like:
+4. Once that has finished try typing `gcc -v` into your terminal window to check the version . You should see the following message:
 
 ```sh
 Configured with: --prefix=/Applications/Xcode.app/Contents/Developer/usr
@@ -32,71 +35,83 @@ Target: x86_64-apple-darwin13.0.0
 Thread model: posix
 ```
 
-If so, congratulations you've installed the compilation tools. You can move onto the next section!
-
 ## Installing homebrew
 
-[Homebrew](http://brew.sh) is a tool that developers use to install other bits of software. Using homebrew we can easily
-install things like the Postgres database tool, or even tools that will allow us to install other tools.
+[Homebrew](http://brew.sh) is a package manager. Using homebrew we can easily install things like the Postgres database tool, or even tools which lets us install other tools.
 
 Installing homebrew is easy. In your terminal window run:
 
-```
-ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+```sh
+/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 ```
 
-Once that is complete you can run `brew -v` in the terminal to check that it has installed properly.
+Once that is complete you can run `brew -v` in the terminal to check the current installed version of homebrew.
 
 ## Installing ruby-install and chruby
 
-ruby-install is a tool that can install multiple versions of the Ruby programming language.
-Professional Ruby developers will use ruby-install (or similar tools) so they can test their
+
+[ruby-install](https://github.com/postmodern/ruby-install) is a tool which can install multiple versions of the Ruby programming language. Professional Ruby developers will use ruby-install (or similar tools) so they can test their
 applications with many different versions of Ruby.
 
-chruby is a tool that can be used to manage and switch between different installed versions
-of Ruby.
+[chruby](https://github.com/postmodern/chruby) is a one of the version managers for Ruby. This manager is used to manage and switch between different installed versions of Ruby.
 
-Run all the the following step by step:
+Run all the the following commands step by step:
 
 1. First install openssl: `brew install openssl`
 2. Next install ruby-install: `brew install ruby-install`
 3. Now use ruby-install to install Ruby: `ruby-install ruby 2.3.0`
 
-Installing Ruby may take a little while. Next we'll install and configure chruby:
+Installing Ruby may take a little while.  
 
-```
-brew install chruby
-echo "source '/usr/local/share/chruby/chruby.sh'" >> ~/.bash_profile
-source '/usr/local/share/chruby/chruby.sh'
-echo "chruby `chruby | grep 2.3.0 | sed 's/\* //'`" >> ~/.bash_profile
-chruby `chruby | grep 2.3.0 | sed 's/\* //'`
-```
+Next we'll install and configure chruby:
 
-This set of commands may seem overwhelming, but all we're doing is:
+1. Install chruby with homebrew: 
 
-1. Installing chruby with homebrew
-2. Configuring chruby to start when you open your terminal.
-3. Starting chruby in your current terminal.
-4. Telling chruby to use the latest version of ruby when your start your terminal.
-5. Telling chruby to use the latest version of ruby in your current terminal.
+    ````sh
+    brew install chruby
+    ````
+
+2. Configure chruby to start when you open your terminal: 
+
+    ````sh 
+    echo "source '/usr/local/share/chruby/chruby.sh'" >> ~/.bash_profile
+    ````
+
+3. Start chruby in your current terminal: 
+
+    ````sh
+    source '/usr/local/share/chruby/chruby.sh'
+    ````
+
+4. Tell chruby to use the latest version of ruby when your start your terminal: 
+
+    ````sh
+    echo "chruby `chruby | grep 2.3.0 | sed 's/\* //'`" >> ~/.bash_profile`
+    ````
+
+5. Tell chruby to use the latest version of ruby in your current terminal: 
+
+    ````sh
+    chruby `chruby | grep 2.3.0 | sed 's/\* //'`
+    ````
 
 Assuming that all worked properly you can run:
 
-```sh
+````sh
 ruby -v
-```
+````
 
 and you should see something like:
 
-```sh
+````sh
 ruby 2.3.0p0 (2015-12-25 revision 53290) [x86_64-darwin13]
-```
+````
 
 Importantly you should NOT see:
 
-```sh
+````sh
 ruby 2.3.0p0 (2015-12-25 revision 53290) [universal.x86_64-darwin13]
-```
+````
 
 The word __universal__ means that it's the version of Ruby which comes with OS X.
 We don't want to use this.


### PR DESCRIPTION
Updated the getting started instructions to reflect a bit more details as well as to be compatible with the latest version of macOS Sierra and Xcode 8.1 accordingly (Command-Line tools come pre-installed by default in [Xcode 8.1](https://developer.apple.com/xcode/features/)).