### PR TITLE
replaced deprecated div_for with content_tag

### DIFF
--- a/source/guides/installfest/getting_started.md
+++ b/source/guides/installfest/getting_started.md
@@ -301,7 +301,7 @@ You've created the database model for your comments, migrated your database, inf
 You'll now need to create a file called `app/views/comments/_comment.html.erb` with the following contents:
 
 ```erb
-<%= div_for comment do %>
+<%= content_tag comment do %>
   <p>
     <strong>
       Posted <%= time_ago_in_words(comment.created_at) %> ago


### PR DESCRIPTION
Running with `div_tag` served up an error with rails 5.1.2.

'`content_tag_for` and `div_for` has been removed in favor of just using `content_tag`' ([A Guide for Upgrading Ruby on Rails, Section 3.15](http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#actionview-helpers-recordtaghelper-moved-to-external-gem-record-tag-helper))
